### PR TITLE
build-info: update Gluon to 2024-05-12

### DIFF
--- a/.github/build-info.json
+++ b/.github/build-info.json
@@ -2,7 +2,7 @@
     "gluon": {
         "repository": "freifunk-gluon/gluon",
         "branch": "master",
-        "commit": "209a881f36957f2cdd3eabd713e68b9bcb23eee3"
+        "commit": "cdb3aa85c5ff1f8087449877d456839f7790d0a6"
     },
     "container": {
         "version": "master"


### PR DESCRIPTION
Update Gluon from 209a881f to cdb3aa85.

~~~
cdb3aa85 ramips/mt7621: add D-Link 878 A1 (#3252)
38f9d018 Merge pull request #3255 from blocktrron/upstream-master-updates
3afbaead modules: update packages
883d27e0 modules: update openwrt
~~~
