### PR TITLE
build-info: update Gluon to 2024-06-10

### DIFF
--- a/.github/build-info.json
+++ b/.github/build-info.json
@@ -2,7 +2,7 @@
     "gluon": {
         "repository": "freifunk-gluon/gluon",
         "branch": "master",
-        "commit": "cdb3aa85c5ff1f8087449877d456839f7790d0a6"
+        "commit": "10728bc8a8ae53f0de8e78ef26497b3aa8826b5a"
     },
     "container": {
         "version": "master"


### PR DESCRIPTION
Update Gluon from cdb3aa85 to 10728bc8.

~~~
10728bc8 Merge pull request #3277 from blocktrron/upstream-master-updates
50c1bceb modules: update packages
ec83aec4 modules: update openwrt
068c12b5 docs: site: pubkey_privacy works for wireguard (#3254)
ff91e601 ramips-mt7621: add support for D-Link DAP-1620 B1 (#3124)
a2e5767f build(deps): bump sphinx from 7.2.6 to 7.3.7 in /docs (#3249)
439dd1f2 build(deps): bump docker/login-action (#3269)
0ffa3f8f build(deps): bump korthout/backport-action from 2.5.0 to 3.0.2 (#3270)
9965def7 Merge pull request #3274 from blocktrron/upstream-master-updates
a79793b3 modules: update routing
628b9043 modules: update packages
66902c71 modules: update openwrt
e0b723ce mpc85xx-p1020: add support for Hewlett-Packard MSM460 (#3272)
fb2c9ae8 Merge pull request #3271 from blocktrron/upstream-master-updates
b75fc3ee modules: update routing
4a8b1f63 modules: update packages
25f0c7d9 modules: update openwrt
d3588a91 Merge pull request #3265 from blocktrron/upstream-master-updates
bc59e3c1 modules: update packages
eb67fabe modules: update openwrt
acc07c60 ath79-generic: TP-Link Archer C7 v2: Fix region selection for factory image (#3259)
~~~