### PR TITLE
build-info: update Gluon to 2024-10-23

### DIFF
--- a/.github/build-info.json
+++ b/.github/build-info.json
@@ -2,7 +2,7 @@
     "gluon": {
         "repository": "freifunk-gluon/gluon",
         "branch": "main",
-        "commit": "10728bc8a8ae53f0de8e78ef26497b3aa8826b5a"
+        "commit": "19cb769b1114446738159f1e493389b66caf2dbf"
     },
     "container": {
         "version": "main"


### PR DESCRIPTION
Update Gluon from 10728bc8 to 19cb769b.

~~~
19cb769b Merge pull request #3353 from neocturne/kirkwood-updates
5ed07dc7 kirkwood-generic: add Linksys EA4500
b03393b2 kirkwood-generic: update reason for BROKEN
31933ff1 Merge pull request #3351 from neocturne/main-updates
f0f50aff modules: update packages
f0d5a821 modules: update openwrt
e6bba9fc Revert "tools flex: disable parallel build (#3169)" (#3350)
145ebf06 Merge pull request #3327 from freifunk-gluon/dependabot/pip/docs/sphinx-8.0.2
ebdd3941 docs: conf.py: update deprecated source_suffix configuration
fa5fbdcb docs: requirements.txt: update to Sphinx 8.0.2 and sphinx-rtd-theme 3.0.0
61ec97e8 Merge pull request #3348 from blocktrron/v2023.2.4-main
8a2baf86 docs readme: Gluon v2023.2.4
91d82e17 docs: add v2023.2.4 release notes
7da85f60 Merge pull request #3346 from freifunk-gluon/dependabot/github_actions/docker/build-push-action-6.9.0
5c5ede37 build(deps): bump docker/build-push-action from 6.7.0 to 6.9.0
c0cbcde8 Merge pull request #3342 from blocktrron/upstream-main-updates
fbe05c91 modules: update packages
e0476386 modules: update openwrt
603a08af Merge pull request #3340 from herbetom/main-updates
54c51d4c modules: update packages
f08b712f modules: update openwrt
52a15803 Merge pull request #3339 from blocktrron/upstream-main-updates
d4d6b243 modules: update packages
e34bc7d7 modules: update openwrt
64f8c066 Merge pull request #3336 from freifunk-gluon/dependabot/github_actions/korthout/backport-action-3.1.0
1c051fca Merge pull request #3335 from freifunk-gluon/dependabot/github_actions/docker/build-push-action-6.7.0
dae99c57 build(deps): bump korthout/backport-action from 3.0.2 to 3.1.0
4891f78f build(deps): bump docker/build-push-action from 6.5.0 to 6.7.0
c5c99358 ath79-generic: add support for DLAN (pro) 1200+ WiFi ac (#3334)
c2568ac2 Merge pull request #3333 from herbetom/main-updates
df918e1a modules: update routing
8cb500a0 modules: update packages
e2c9d608 modules: update openwrt
7de13bcb Merge pull request #3329 from freifunk-gluon/dependabot/github_actions/docker/build-push-action-6.5.0
771f3ac0 Merge pull request #3328 from freifunk-gluon/dependabot/github_actions/docker/login-action-3.3.0
f729aac2 Merge pull request #3188 from maurerle/improve_docs
43a880e4 docs: apply suggestions from code review
f0311a60 build(deps): bump docker/build-push-action from 6.2.0 to 6.5.0
5ef633d1 build(deps): bump docker/login-action from 3.2.0 to 3.3.0
23ff99be Merge pull request #3312 from grische/fix/ports-on-7520-v2
6f6c300e Merge pull request #3324 from blocktrron/upstream-main-updates
05a40de6 modules: update routing
fc96dcf9 modules: update packages
97ede66b modules: update openwrt
e3139b5b scripts: enable checks for unassigned uppercase (#3302)
93b600a9 Merge pull request #3301 from grische/read-feeds-dynamically-update-modules
f7d41c50 Merge pull request #3303 from grische/remove-scripts-wide-shellcheck-excludes
e9acd522  scripts: add --tags to git describe in getversion.sh to include lightweighted tags (#3310)
27fe1ed4 gluon-core: migrate lan role of single port config
be4213de fritzbox-7530: utilize lan1 as wan, others as lan With the switch to DSA on this board, we can now utilize the ports better, by splitting them according to their usage
d7ed2dfc Merge pull request #3317 from blocktrron/upstream-main-updates
2b99a849 modules: update packages
b463adb1 modules: update openwrt
5a854853 gluon-web-cellular: add auth option to GUI (#3307)
1fd073af docs: add documentation to gluon-config-mode-geo-location-osm package
213b980f docs: add picture to configmode page
823a3601 docs autoupdater: fix manifest underline
1dd05dbe docs status-page: add docs about status-page feature
34a29c7b docs x86: Prefer x86-64 bit (alphanumerical order) Add information about old x86 images
60b4a102 docs gluon-tls: add documentation about gluon-tls feature
3d1baf62 docs configmode: add links to specific package docs of config mode
e1415963 docs: add docs for gluon-web-cellular
dc51f3d3 Add documentation for evaluation of mesh-vpn protocols (#3267)
d9cfa194 gluon-core: fix swconfig detection in ethernet module (#3309)
ec0b2a4a docs: add documentation about gluon-web-network package * document network roles and their effects
2cef1aeb docs: add note about outdoor mode to wlan-configuration
7df8c628 Merge pull request #3306 from herbetom/main-updates
5e5433da modules: update packages
5ab7964f modules: update openwrt
1af5605c ramips-mt7620: add support for Netgear EX6130 (#3304)
b50007d1 ramips-mt7621: add support for Xiaomi Mi Router 4a Gigabit Edition v2 (#3293)
9cdd8d51 mesh-vpn-wireguard: fix set incorrect MTU on the wireguard interface (#3258)
b6f7e4bc scripts: module-check: replace eval with indirection
cf0d2ced scripts: update: replace evals with indirection
deae3d10 scripts: remove scripts-wide shellcheck excludes
2c9d982e scripts: update-modules: fix SC2086
92d4631f scripts: update-modules: read feeds from modules
fe2273ea build(deps): bump docker/build-push-action from 5.4.0 to 6.2.0 (#3300)
d5d6d0f7 mt76: include fixes for MT7603 / MT7612 (#3261)
d72dabcf Merge pull request #3299 from blocktrron/upstream-main-updates
a3e1288f modules: update packages
f3499bf1 modules: update openwrt
68f6710d private-wifi: rename ifname to wl-wanX  (#3294)
bdf74d81 ramips-mt76x8: add TP-Link RE200 v4 (#3297)
c61456e3 Merge pull request #3295 from neocturne/debug-default
0f0cbaa5 docs: user/getting_started: fix monospace markup
d09cda05 build: extend GLUON_DEBUG with values 0, 1 and 2
f70526cd Merge pull request #3292 from neocturne/linksys-e4200-v2-fix
fc44ba5a kirkwood-generic: fix device name of Linksys E4200 v2
986679a4 Merge pull request #3289 from herbetom/main-updates
b8223e91 modules: update packages
4b45ab0f modules: update openwrt
70b7c2f2 build(deps): bump docker/build-push-action from 5.3.0 to 5.4.0 (#3281)
4050b9e4 Merge pull request #3287 from blocktrron/upstream-main-updates
d5258e37 modules: update packages
b7390d1e modules: update openwrt
d1ec30ba Merge pull request #3285 from blocktrron/upstream-main-updates
49be1685 modules: update packages
b9b7e1db modules: update openwrt
3f57bc68 Merge pull request #3283 from blocktrron/pr-main-v2023.2.3-rn
349d0f36 docs readme: Gluon v2023.2.3
f12984e0 docs: add v2023.2.3 release notes
fab66392 treewide: Update main branch name (#3282)
~~~
