### PR TITLE
build-info: update Gluon to 2024-11-14

### DIFF
--- a/.github/build-info.json
+++ b/.github/build-info.json
@@ -2,7 +2,7 @@
     "gluon": {
         "repository": "freifunk-gluon/gluon",
         "branch": "main",
-        "commit": "19cb769b1114446738159f1e493389b66caf2dbf"
+        "commit": "33f6538c53f66b70a6d4a34020c162fa54b748a0"
     },
     "container": {
         "version": "main"


### PR DESCRIPTION
Update Gluon from 19cb769b to 33f6538c.

~~~
33f6538c Merge pull request #3374 from blocktrron/upstream-main-updates
4b0d5f50 modules: update routing
edd07a55 modules: update packages
dd907e68 modules: update openwrt
7cc3ebdd ipq806x-generic: add Ubiquiti UniFi AC HD (#3361)
d3813362 generic: add gluon grub title (#3366)
a836ae7a ramips-mt7621: add Ubiquiti UniFi nanoHD (#3362)
873e5f7b docs readme: update hackint webchat URL (#3360)
~~~

Signed-off-by: GitHub Actions <info@freifunk-rhein-neckar.de>