### PR TITLE
build-info: update Gluon to 2024-11-23

### DIFF
--- a/.github/build-info.json
+++ b/.github/build-info.json
@@ -2,7 +2,7 @@
     "gluon": {
         "repository": "freifunk-gluon/gluon",
         "branch": "main",
-        "commit": "19cb769b1114446738159f1e493389b66caf2dbf"
+        "commit": "f3cae19c6b72a99793f2dcb087c72aa2d756d355"
     },
     "container": {
         "version": "main"


### PR DESCRIPTION
Update Gluon from 19cb769b to f3cae19c.

~~~
f3cae19c Merge pull request #3378 from blocktrron/upstream-main-updates
bf33ce4e modules: update packages
87ce9825 modules: update openwrt
33f6538c Merge pull request #3374 from blocktrron/upstream-main-updates
4b0d5f50 modules: update routing
edd07a55 modules: update packages
dd907e68 modules: update openwrt
7cc3ebdd ipq806x-generic: add Ubiquiti UniFi AC HD (#3361)
d3813362 generic: add gluon grub title (#3366)
a836ae7a ramips-mt7621: add Ubiquiti UniFi nanoHD (#3362)
873e5f7b docs readme: update hackint webchat URL (#3360)
~~~

Signed-off-by: GitHub Actions <info@freifunk-rhein-neckar.de>