### PR TITLE
build-info: update Gluon to 2024-12-11

### DIFF
--- a/.github/build-info.json
+++ b/.github/build-info.json
@@ -2,7 +2,7 @@
     "gluon": {
         "repository": "freifunk-gluon/gluon",
         "branch": "main",
-        "commit": "f3cae19c6b72a99793f2dcb087c72aa2d756d355"
+        "commit": "b180fc2889f53a8dd4945dba5d783e41aa63c38b"
     },
     "container": {
         "version": "main"


### PR DESCRIPTION
Update Gluon from f3cae19c to b180fc28.

~~~
b180fc28 Merge pull request #3363 from freifunk-gluon/dependabot/pip/docs/sphinx-8.1.3
608a6658 Merge pull request #3382 from freifunk-gluon/dependabot/github_actions/docker/metadata-action-5.6.1
80a16ba0 Merge pull request #3383 from freifunk-gluon/dependabot/github_actions/docker/build-push-action-6.10.0
d16fe2ae docs: user/supported_devices: remove unreferenced footnote
9dd90850 build(deps): bump sphinx from 8.0.2 to 8.1.3 in /docs
92845384 Merge pull request #3381 from freifunk-gluon/dependabot/pip/docs/sphinx-rtd-theme-3.0.2
adbb283e Merge pull request #3380 from grische/add-nanopi-r3s-support
f18b1d9f Merge pull request #3372 from T-X/pr-openwrt-24.10-bridge-wakeupcall
b4b3cb29 Merge pull request #3371 from T-X/pr-openwrt-24.10-batman-adv-noflood
aa39a94e add support for NanoPi R3S
2b129f68 kernel: bridge: readding MLD wakeup call feature
bfff4233 Revert "routing: remove noflood"
f18a350a Merge pull request #3370 from freifunk-gluon/openwrt-24.10
77a83ce1 generic: enable kernel namespace support
4bbe5550 generic: fix ramips-mt76x8 compile
b7481fd0 modules: switch to OpenWrt 24.10
3688bf2e scripts: remove temporary output directory
224d0aa7 ramips-mt7621: remove Edgerouter X
35b70fce mediatek-mt7622: remove Xiaomi Redmi AX6S
702211ac routing: remove noflood
b1cdcc87 docker: add missing dependencies
7c0b77b3 build(deps): bump docker/build-push-action from 6.9.0 to 6.10.0
43861fa6 build(deps): bump docker/metadata-action from 5.5.1 to 5.6.1
b31f045d build(deps): bump sphinx-rtd-theme from 3.0.0 to 3.0.2 in /docs
~~~

Signed-off-by: GitHub Actions <info@freifunk-rhein-neckar.de>