### PR TITLE
build-info: update Gluon to 2025-05-05

### DIFF
--- a/.github/build-info.json
+++ b/.github/build-info.json
@@ -2,7 +2,7 @@
     "gluon": {
         "repository": "freifunk-gluon/gluon",
         "branch": "main",
-        "commit": "b180fc2889f53a8dd4945dba5d783e41aa63c38b"
+        "commit": "4afdc22715db10ae5055fce6f24fdf2464f61ec3"
     },
     "container": {
         "version": "main"


### PR DESCRIPTION
Update Gluon from b180fc28 to 4afdc227.

~~~
4afdc227 Merge pull request #3496 from herbetom/respondd-taget-info
adcedf15 package/gluon-respondd: add target information
5dc5301a Merge pull request #3495 from freifunk-gluon/dependabot/github_actions/docker/build-push-action-6.16.0
57e297ef build(deps): bump docker/build-push-action from 6.15.0 to 6.16.0
4627d80d Merge pull request #3494 from herbetom/main-updates
0212815e modules: update routing
181de471 modules: update packages
e22840e2 modules: update openwrt
4be93f94 Merge pull request #3493 from blocktrron/tr1200
25c0dacc Merge pull request #3492 from blocktrron/pr-mt2500
8720ce43 ath79-nand:  add support for GL.iNet E750 (#3476)
08ea643f ramips-mt76x8: add support for Cudy TR1200 v1
6d2e0183 mediatek-filogic: add GL.iNet GL-MT2500
08ce23fc ramips-mt76x8: add support for TP-Link TL-WR902AC v4 (#3491)
84fb35d0 mediatek-filogic: add support for Cudy TR3000 v1 (#3473)
f1349022 Merge pull request #3488 from blocktrron/pr-bugfix-dnsmasq-ex25519-small-flash
5d9532ae Merge pull request #3480 from blocktrron/pr-dsa-conduit
3c0186c6 gluon-core: use single conduit interface for DSA topology
c91c76b2 generic: enable dnsmasq ed25519 keys regardless of target
d8145f83 Merge pull request #3457 from neocturne/shellcheck
377b03b9 Merge pull request #3485 from freifunk-gluon/issue-2081
79dc555b core: remove transitive option from network interfaces
8580bd91 Merge pull request #3477 from neocturne/block-nested-vxlan
fef15507 Merge pull request #3478 from neocturne/remove-node_client_prefix6
090bcda7 gluon-ebtables-filter-multicast: block packets with Gluon VXLAN multicast destination
a4b078d6 gluon-mesh-layer3-common: remove deprecated node_client_prefix6 from site
373e2b8e Merge pull request #3475 from neocturne/main-updates
9f6e4578 modules: update packages
3a15c4e7 modules: update openwrt
c4e8f9fe Merge pull request #3474 from neocturne/main-updates
72927cad modules: update openwrt
974e4544 Merge pull request #3472 from herbetom/main-updates
091ced3f Merge pull request #3471 from neocturne/lint-initscripts
da89dff8 modules: update packages
b741dc46 modules: update gluon
0da16425 modules: update openwrt
e94775f1 lint: sh: add checking for initscripts
c2d14538 lint: sh: improve shellscript detection
085250c2 treewide: fix or disable lint warnings in initscripts
60734d56 perl: drop patch to disable parallel build (#3470)
892fd149 Merge pull request #3468 from freifunk-gluon/dependabot/github_actions/docker/login-action-3.4.0
c45fc618 build(deps): bump docker/login-action from 3.3.0 to 3.4.0
e1bb8949 gluon-mesh-vpn-wireguard: fix shellcheck warnings in netifd proto
caba048e Merge pull request #3467 from neocturne/shellcheck2
6cd474b7 Merge pull request #3465 from neocturne/no-keep-opkg-keys
fe91b041 Merge pull request #3463 from neocturne/autoupdater-https
517433e8 Merge pull request #3464 from neocturne/wan-dnsmasq-ujail
092a086d lint: sh: enable previously disabled warnings
604e7e54 treewide: fix previously disabled shellcheck warnings
bd746da4 gluon-mesh-vpn-*: move gluon_wireguard netifd proto to gluon-mesh-vpn-wireguard
f1bd38dc opkg: do not preserve opkg keys on upgrades by default
dc13c17a gluon-wan-dnsmasq: add ujail configuration
4ccb5ccb gluon-wan-dnsmasq: run as dnsmasq user/group
f9c341a3 gluon-wan-dnsmasq: use long option names
715abd7f Merge pull request #3414 from ChristianMiddendorf/main
c800fe7f gluon-autoupdater: add support for HTTPS and protocol-less URLs
877ae95a gluon-tls: add marker file
078006f8 ramips-mt76x8: add support for Xiaomi Mi Router 4A (100M International Edition v2 - R4ACv2)
1de93e1e docs: ramips-mt76x8: add Xiaomi Mi Router 4 model IDs
4b3eb116 Merge pull request #3461 from neocturne/drop-realtek-rtl838x
4e847f7e hardware: remove support for D-Link DGS-1210-10P and realtek-rtl838x target
1be370b4 Merge pull request #3460 from herbetom/main-updates
c8ef95c7 modules: update packages
b8e5ae9e modules: update openwrt
28f2ee9a Merge pull request #3445 from freifunk-gluon/dependabot/pip/docs/sphinx-8.2.1
6ca4d7b9 docs: bump sphinx from 8.1.3 to 8.2.3
44a9abd0 actions: build docs on Ubuntu 24.04
91264654 Merge pull request #3406 from ffac/remove_migrations
d7225ba7 core: remove old migrations
5e1849e2 Merge pull request #3355 from blocktrron/poe-passthrough-active-low
ed8de418 Merge pull request #3424 from herbetom/fixup-toollist-getting_started
d91f3f34 docs: user/getting_started: add dependencies
e2de86ce Merge pull request #3449 from herbetom/main-refresh-patches
d29174ba patches: refresh-patches
cf9f0f92 Merge pull request #3436 from blocktrron/mt7915-20250113-restart
55d654ff mediatek-filogic: add support for OpenWRT One (#3446)
1feed04d actions: remove non-required packages (#3448)
37886a4c Merge pull request #3447 from blocktrron/upstream-main-updates
2f9461df openwrt: remove mt76 patch
937d25be build: use host LLVM toolchain
8d50f440 Merge pull request #3444 from freifunk-gluon/dependabot/github_actions/korthout/backport-action-3.2.0
ace6ebcd Merge pull request #3443 from freifunk-gluon/dependabot/github_actions/docker/metadata-action-5.7.0
dcf67010 Merge pull request #3442 from freifunk-gluon/dependabot/github_actions/docker/build-push-action-6.15.0
f42266d3 contrib docker: sort package-list
c98454eb modules: update routing
e3120771 modules: update packages
ad1bea9c modules: update openwrt
5f77bba0 build(deps): bump korthout/backport-action from 3.1.0 to 3.2.0
7a98065d build(deps): bump docker/metadata-action from 5.6.1 to 5.7.0
a48d30d8 build(deps): bump docker/build-push-action from 6.13.0 to 6.15.0
49079cfb Merge pull request #3427 from ffac/rssi_for_5ghz
56f9f391 Merge pull request #3437 from freifunk-gluon/dependabot/github_actions/docker/build-push-action-6.13.0
94a7eb1b mt76: import MT7915 recovery fixes
ae807135 build(deps): bump docker/build-push-action from 6.10.0 to 6.13.0
cd074cc9 Merge pull request #3434 from ffac/update-openwrt-main
7e619101 Merge pull request #3432 from ffac/tplink_ax23
3035005d modules: update packages
02cf7d43 modules: update openwrt
5b4e1091 ramips-mt7621: add tp-link ax23
ff58f65a ramips-mt7621: add support netgear eax12 (#3433)
ad321f50 Merge pull request #3429 from ffac/update-openwrt-main
a4c78821 modules: update packages
368ee823 modules: update openwrt
4e2188a7 gluon-core: set 5GHz rssi leds to mesh1 connectivity
3c04d32d Merge pull request #3428 from blocktrron/upstream-main-updates
8f853668 armsr: change image name
2cf299d8 modules: update routing
e2b5bca6 modules: update packages
8137470e modules: update openwrt
ab1c3118 net: mac80211: force backwards compatible basic rates (#3419)
24a5fd4d Merge pull request #3421 from ffac/update-openwrt-main
56ad0ae9 Merge pull request #3422 from s-2/m30
b3130ff4 docs: move D-Link M30, M60 to mediatek-filogic
c99f9c04 modules: update packages
e9098728 modules: update openwrt
791e39f4 Merge pull request #3407 from RolandoMagico/M60
0b23f899 mac80211: silence mesh rate mismatch warning (#3416)
b0671dd7 gluon-web-network: support handling of active-low PoE passthrough
9c914db0 mediatek-filogic: Add support for D-Link AQUILA PRO AI M60 A1
a475b191 gluon-private-wifi: rename psk3 to sae
4c7aef6e Merge pull request #3411 from blocktrron/upstream-main-updates
912527ab wifi-scripts: allow per-IF mesh basic rate selection
fb08eabb gluon-core: set basic-rate for mesh interface
06e421ed net: mac80211: always pretend 1 Mbit/s as mesh basic rate
d6e74f00 net: mac80211: override incompatible basic-rates for mesh
ebc4a606 generic: rename SECCOMP config option
f168aca9 modules: update packages
fbe070c4 modules: update openwrt
e5675adc docs: add AP3915i to supported_devices (#3413)
c31c7d75 Merge pull request #3405 from ffac/allow_fb7530_dsl
828ac800 Merge pull request #3396 from ffac/ap3915i
d87fadb7 ipq40xx-generic: add extreme-networks-ws-ap3915i
e1523af5 Merge pull request #3401 from ffac/update-openwrt-main-1734975929
6b80b580 mediatek-filogic: add Cudy AP3000 Outdoor v1 (#3384)
b5ba291b readd moved xrx200_legacy target
b110494f remove devices which were moved to lantiq-xrx200_legacy
b720d4d0 patches: make refresh-patches
d66cfc0c modules: update packages
9271070c modules: update openwrt
1757fff8 ipq40xx-generic: add working VDSL config for FB7530
4f6de05a Merge pull request #3403 from ffac/silence_airtime_link_metric_get
e594ce2e mac80211: silence warning for missing rate information
717bf99c Merge pull request #3400 from RolandoMagico/D-Link_M30
1e50f2e4 mediatek-filogic: Add support for D-Link AQUILA PRO AI M30 A1
fc25b494 Merge pull request #3394 from grische/drop-python3-distutils
246489be Merge pull request #3399 from ffac/update-openwrt-main-1734601207
f2aeb462 ath79: Add support for Sophos AP15C (#3385)
def60f86 modules: update routing
8998470d modules: update packages
c5700b64 modules: update openwrt
3af76af4 Merge pull request #3387 from herbetom/main-updates
3654f83a libgluonutil: add missing libgen import (#3395)
51719c69 Dockerfile: drop dependency on python3-distutils
879e4501 modules: update routing
36d907fe modules: update packages
a625ae4f modules: update openwrt
~~~

Signed-off-by: GitHub Actions <info@freifunk-rhein-neckar.de>