### PR TITLE
ci: build: remove non-required packages

### DIFF
--- a/.github/free-runner-space.sh
+++ b/.github/free-runner-space.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# For a List of pre-installed packages on the runner image see
+# https://github.com/actions/runner-images/tree/main?tab=readme-ov-file#available-images
+
+echo "Disk space before cleanup"
+df -h
+
+# Remove packages not required to run the Gluon build CI
+sudo apt-get -y remove \
+	dotnet-* \
+	firefox \
+	google-chrome-stable \
+	kubectl \
+	microsoft-edge-stable \
+	temurin-*-jdk
+
+# Remove Android SDK tools
+sudo rm -rf /usr/local/lib/android
+
+echo "Disk space after cleanup"
+df -h

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -261,16 +261,15 @@ jobs:
     name: All Targets Build
     runs-on: ubuntu-22.04
     needs: [build, build-meta, targets]
-    if: ${{ always() }}
+    if: ${{ !cancelled() }}
     steps:
-      - name: Error out if there is a failure
-        if: ${{ needs.build_firmware.result != 'success' }}
+      - name: Error out because there is a failure
+        if: ${{ failure() }}
         run: |
           echo "One or more builds failed."
           exit 1
-      - name: Proceed if all passed
-        if: ${{ needs.build_firmware.result == 'success' }}
-        run: echo "All required builds succeded!"
+      - name: Error out because there is a failure
+        run: echo "All firmware builds succeded!"
 
   manifest:
     needs: [build, build-meta, targets]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -211,6 +211,9 @@ jobs:
       - name: Print meminfo
         run: cat /proc/meminfo
 
+      - name: Remove non-required software
+        run: bash .github/free-runner-space.sh
+
       - name: Download prepared OpenWrt
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
The current ~21G of free space don't seem to be enough for mediatek-filogic anymore.

Remedy this by removing unnessary packages. Based on https://github.com/freifunk-gluon/gluon/pull/3448

---

Also (hopefully) fix the matrix status check.

---

replaces #10