### PR TITLE
build-info: update Gluon to 2025-05-15

### DIFF
--- a/.github/build-info.json
+++ b/.github/build-info.json
@@ -2,7 +2,7 @@
     "gluon": {
         "repository": "freifunk-gluon/gluon",
         "branch": "main",
-        "commit": "4afdc22715db10ae5055fce6f24fdf2464f61ec3"
+        "commit": "d8177d641f55cb8bc3b963427177b6c41081b690"
     },
     "container": {
         "version": "main"


### PR DESCRIPTION
Update Gluon from 4afdc227 to d8177d64.

~~~
d8177d64 Merge pull request #3508 from blocktrron/pr-bootcount
0f66e109 Merge pull request #3507 from blocktrron/upstream-main-updates
5c064002 gluon-setup-mode: execute bootcount initscript in setup-mode
067c1a38 modules: update packages
8a0b9040 modules: update openwrt
a596d37b Merge pull request #3505 from blocktrron/pr-ex400
d614d9aa Merge pull request #3506 from blocktrron/pr-ax52
caf75dd9 ramips-mt7621: add support for Genexis Pulse EX400
364a4bdb mediatek-filogic: add ASUS RT-AX52
91c2bba3 Merge pull request #3504 from blocktrron/upstream-main-updates
15f85a47 modules: update packages
51b37987 modules: update gluon
d9ab6c3a modules: update openwrt
d2a85227 Merge pull request #3503 from neocturne/info-i18n
0a858a3a gluon-core: fix German translation for "Switch type"
37bc9415 gluon-core, gluon-web-admin: move translations for gluon-info strings to gluon-core
76561294 Merge pull request #3502 from ffac/improve_docs
4fc56afb docs: gluon-web-network: fix  enumerations
~~~

Signed-off-by: GitHub Actions <info@freifunk-rhein-neckar.de>