### PR TITLE
build-info: update Gluon to 2025-07-16; modules: update community repo hash; site.conf: node_whisperer: disable domain

### DIFF
--- a/.github/build-info.json
+++ b/.github/build-info.json
@@ -2,7 +2,7 @@
     "gluon": {
         "repository": "freifunk-gluon/gluon",
         "branch": "main",
-        "commit": "d8177d641f55cb8bc3b963427177b6c41081b690"
+        "commit": "7b3f7e10197fd8b4672db80dcd5a7eab1044ba43"
     },
     "container": {
         "version": "main"

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,27 @@
+---
+name: Backport
+
+# yamllint disable-line rule:truthy
+on:
+  pull_request_target:
+    types: [closed, labeled]
+
+permissions:
+  contents: write  # so it can comment
+  pull-requests: write  # so it can create pull requests
+
+jobs:
+  # yamllint disable rule:line-length
+  backport:
+    name: Backport Pull Request
+    if: github.repository_owner == 'Freifunk-Rhein-Neckar' && github.event.pull_request.merged == true && (github.event_name != 'labeled' || startsWith('backport', github.event.label.name))
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Create backport PRs
+        uses: korthout/backport-action@v3.2.0
+        with:
+          # Config README: https://github.com/korthout/backport-action#backport-action
+          pull_description: |-
+            Automatic backport to `${target_branch}`, triggered by a label in #${pull_number}.
+   # yamllint enable rule:line-length

--- a/image-customization.lua
+++ b/image-customization.lua
@@ -25,6 +25,17 @@ packages({
 	'ffda-node-whisperer',
 })
 
+-- Enable SQM only on targets which have the CPU capabilities
+-- to use CAKE
+if not target('ath79')
+	and not target('ramips')
+	and not target('lantiq')
+	then
+	features({
+		'mesh-vpn-sqm'
+	})
+end
+
 -- Packages and features for devices which are not flagged as tiny
 if not device_class('tiny') then
 	packages({
@@ -32,7 +43,6 @@ if not device_class('tiny') then
 	})
 
 	features({
-		'mesh-vpn-sqm',
 		'tls',
 		'web-cellular',
 		'wireless-encryption-wpa3'

--- a/modules
+++ b/modules
@@ -4,4 +4,4 @@ PACKAGES_FFRN_REPO=https://github.com/Freifunk-Rhein-Neckar/ffrn-packages.git
 PACKAGES_FFRN_COMMIT=b50c8ff1616b80dc0180adbee0b578c97ae4d0b6
 
 PACKAGES_COMMUNITY_REPO=https://github.com/freifunk-gluon/community-packages.git
-PACKAGES_COMMUNITY_COMMIT=bd78c4cea3fd2e203c0628ded1098c7a92cb3ae4
+PACKAGES_COMMUNITY_COMMIT=4a90cd221e8eba254ffc8dc5addbf3374b830415

--- a/site.conf
+++ b/site.conf
@@ -123,7 +123,6 @@
 			'node_id',
 			'uptime',
 			'site_code',
-			'domain',
 			'system_load',
 			'firmware_version',
 			'batman_adv',


### PR DESCRIPTION
Update Gluon from d8177d64 to 7b3f7e10.

~~~
7b3f7e10 Merge pull request #3544 from freifunk-gluon/feat/add-gl-inet-gl-ar300m16
46e4e47e Merge pull request #3545 from freifunk-gluon/feat/add-google-wifi-gale
f05524e3 ipq40xx-chromium: add support for Google WiFi (Gale)
c4d32370 ath79-generic: add support for GL.iNet GL-AR300M16
bbbc94d9 Merge pull request #3536 from freifunk-gluon/feat/gluon-schduled-domain-switch-no-ping
0e6a2671 Merge pull request #3541 from freifunk-gluon/feat/gluon-harden-dropbear
e878e433 gluon-harden-dropbear: Add package
eb824ed4 gluon-autoupdater: Omit in_site filter
6cfbafaf gluon-scheduled-domain-switch: Replace ping with gluon-state checks
9c90a1c9 Merge pull request #3543 from freifunk-gluon/docs/ecdsa_signing
104917a5 docs: Add info about ECDSA keys
ace4f647 Merge pull request #3148 from neocturne/image-customization-include
7f583d2a Merge pull request #3542 from freifunk-gluon/refactor/move-ntpd-state-check
1aa95a05 Merge pull request #3510 from s-2/wn573hx3
41d15b3b mediatek-filogic: add Wavlink WL-WN573HX3
e8502ca0 gluon-state-check: Merge with gluon-state-ntpd-check
70b4e729 scripts: image_customization_lib: add include() function
6973d479 scripts: image_customization_lib: reword and add more argument checks
4637c79e docs: user/site: add examples for image customization functions
bb3a6f32 docs: site-example: add trailing commas in image-customization
ecacd5ec Makefile: improve error messages
1ad9a3a9 Merge pull request #3538 from freifunk-gluon/dependabot/github_actions/korthout/backport-action-3.2.1
31e745d6 build(deps): bump korthout/backport-action from 3.2.0 to 3.2.1
d38f0bd0 Merge pull request #3532 from dg0tm/gluon-l2roamd
feccb9d1 Merge pull request #3530 from freifunk-gluon/docs/unsupported-uci-options
0bd0cf88 docs: Add FAQ sections for setting retention and gluon_preserve
e80777b8 Merge pull request #3527 from dg0tm/main
e33e32ef gluon-l3roamd: startup fix
44073921 ramips-mt7621: add back Edgerouter X" (#3533)
c8b1dad3 Merge pull request #3529 from freifunk-gluon/main-updates
000b6e51 modules: update routing
acd7cf9d modules: update packages
bdf0720e modules: update openwrt
d7619c60 gluon-state-ntpd-check: Add package (#3528)
9794e83b Merge pull request #3097 from blocktrron/openwrt-profile-info
642e6313 ci: seperately store metadata output
367d8e52 ci: check build-output image size
7f14b431 contrib: add script for validating image-size
321cd5b1 build: include size-limits to device-metadata
06273248 build: copy OpenWrt profile JSON
dbf3e4d6 gluon-mesh-layer3-common: get rid of substitution count returned by gsub on prefix
0193319a Merge pull request #3522 from blocktrron/pr-genexis-touch-disable
ed67c780 Merge pull request #3484 from ffac/add_autoupdater_info
193660e2 gluon-core: make clear if mesh-vpn/public vpn key is disabled correctly in gluon-info
1a8257ec gluon-core: add autoupdater info to gluon-info
ed6823b8 gluon-setup-mode: ignore capacitive buttons on Pulse EX400
464fc6d4 Merge pull request #3517 from blocktrron/pr-v2023.2.5-main
f4cb2e2d docs: releases/v2023.2.5: fix typo
840c2c18 Merge pull request #3518 from freifunk-gluon/dependabot/github_actions/docker/build-push-action-6.18.0
41763441 build(deps): bump docker/build-push-action from 6.16.0 to 6.18.0
06bc963a docs readme: Gluon v2023.2.5
8fd5f11b docs: add Gluon v2023.2.5 release notes
73865b6d Merge pull request #3514 from blocktrron/upstream-main-updates
a6135ecb modules: update packages
c9217c43 modules: update openwrt
480fdf57 Merge pull request #3511 from freifunk-gluon/refactor/env-bash
a80f65c1 scripts: Alter shebangs to /usr/bin/env bash
~~~

Signed-off-by: GitHub Actions <info@freifunk-rhein-neckar.de>
