### PR TITLE
build-info: update Gluon to 2025-07-31

### DIFF
--- a/.github/build-info.json
+++ b/.github/build-info.json
@@ -2,7 +2,7 @@
     "gluon": {
         "repository": "freifunk-gluon/gluon",
         "branch": "main",
-        "commit": "a05a0f8efa0505a4163375dc469930665f6f9865"
+        "commit": "9143b02374322d304386f87b1c67e81c345c49e6"
     },
     "container": {
         "version": "main"


### PR DESCRIPTION
Update Gluon from a05a0f8e to 9143b023.

~~~
9143b023 Merge pull request #3454 from ffac/per_hardif_hop_penalty
7d8cbdee docs: add documentation about tweaking hop penalties
e18fdf40 gluon-core: copy hop_penalty from gluon.batadv_hop_penalty to gluon_mesh
0c306292 gluon-core: allow setting hop_penalty in network
4fa712bd Merge pull request #3557 from blocktrron/pr-wps-script-removal
3b8dff36 Merge pull request #3512 from Djfe/mesh_nolearn
57cafa3a openwrt hostapd: disable WPS button handling
768172c7 gluon-core: activate mesh_nolearn
551bdb7a Merge pull request #3516 from grische/add-ws-ap3935i
fa8f40ee ipq806x-generic: add Extreme Networks WS-AP3935i
b3344085 Merge pull request #3551 from neocturne/role-custom-data
7bb2144e Merge pull request #3469 from neocturne/dropbear-mount-ns
fe395176 Merge pull request #3537 from FreifunkChemnitz/fritz7430
02c43707 lantiq-xrx200: Add support for FritzBox 7430
afa1c7dc docs: Add install command and change debian release (#3548)
d4c56c2b gluon-core: gluon.util: introduce get_role_interfaces_with_options()
69fddaaa dropbear: drop failsafe mode patch
18879e28 gluon-setup-mode: namespace-based implementation for password-less login
2cb91fdc gluon-setup-mode: simplify dropbear init script
c6735429 gluon-setup-mode: drop unused script ash-login
~~~

Signed-off-by: GitHub Actions <info@freifunk-rhein-neckar.de>