### PR TITLE
build-info: update Gluon to 2025-08-19

### DIFF
--- a/.github/build-info.json
+++ b/.github/build-info.json
@@ -2,7 +2,7 @@
     "gluon": {
         "repository": "freifunk-gluon/gluon",
         "branch": "main",
-        "commit": "9143b02374322d304386f87b1c67e81c345c49e6"
+        "commit": "e00940ef53e55098e995b6e0329723077fe1cede"
     },
     "container": {
         "version": "main"


### PR DESCRIPTION
Update Gluon from 9143b023 to e00940ef.

~~~
e00940ef mvebu-cortexa53: add support for GL.iNet GL-MV1000 (#3562)
125090b9 Merge pull request #3566 from herbetom/main-updates
051d30d6 modules: update routing
0a92cd44 modules: update packages
dcf5ff58 modules: update openwrt
6d3ceffc Merge pull request #3556 from ffac/fix_default_gw4_for_parker
bd1d2b18 gluon-mesh-batman-adv: improve has_default_gw4 for parker
240a3b3c Merge pull request #3559 from FreifunkChemnitz/ax3000t
018f945b mediatek: filogic: add support for Xiaomi AX3000T
033a9ebe Merge pull request #3553 from FreifunkChemnitz/cpe710v2
6992ceb3 ath79-generic: add support for TP-Link CPE710-v2
~~~

Signed-off-by: GitHub Actions <info@freifunk-rhein-neckar.de>